### PR TITLE
Add support for KJ and replace deprecated function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Myfitnesspal custom component
-This custom component gets fitnessdata from your account. Please advice that the component uses underlying scraping API:s that can change at any time and used at your own risk. **The author takes no liability of usage**.
+This custom component gets fitness data from your account. Please note that the component uses an underlying scraping API that can change at any time and use at your own risk. **The author takes no liability of usage**.
 
 # Usage
 
 ## Copy and paste
 *If you use HACS, skip this step!*
-The component can be used by copy everything under `custom_component` folder to your `custom_component`, i.e. the `my_fitnesspal` folder.
+The component can be used by copying everything under the `custom_component` folder to your `custom_component`, i.e. the `my_fitnesspal` folder.
 
-### Configure trough integrations (prefered way)
+### Configure through integrations (prefered way)
 Check under configuration/integrations. Add the `Myfitnesspal` integration.
 
 ### Configure with old school yaml
@@ -25,4 +25,4 @@ Not supported
 ## HACS component
 You can use HACS [Se this link for more information](https://github.com/custom-components/hacs). Add `https://github.com/helto4real/custom_component_myfitnesspal` to custom repository under `SETTINGS`. Select integration as type.
 
-Configure through integrationspage or old school yaml as described above.
+Configure through the integrations page or old school yaml as described above.

--- a/custom_components/my_fitnesspal/__init__.py
+++ b/custom_components/my_fitnesspal/__init__.py
@@ -141,14 +141,24 @@ class MyFitnessPalDataUpdateCoordinator(DataUpdateCoordinator):
             if len(latest_record) > 1:
                 latest_weight = latest_record[1]
 
-        goal_calories = info.goals.get("calories", 0)
+        goal_calories = info.goals.get("calories",
+            round(info.goals.get("kilojoules", 0)  / 4.184)
+        )
+        goal_kilojoules = info.goals.get("kilojoules",
+            round(info.goals.get("calories", 0) * 4.184)
+        )
         goal_carbohydrates = info.goals.get("carbohydrates", 0)
         goal_fat = info.goals.get("fat", 0)
         goal_sodium = info.goals.get("sodium", 0)
         goal_sugar = info.goals.get("sugar", 0)
         goal_protein = info.goals.get("protein", 0)
 
-        total_calories = info.totals.get("calories", 0)
+        total_calories = info.totals.get("calories",
+            round(info.totals.get("kilojoules", 0)  / 4.184)
+        )
+        total_kilojoules = info.totals.get("kilojoules",
+            round(info.totals.get("calories", 0) * 4.184)
+        )
         total_carbohydrates = info.totals.get("carbohydrates", 0)
         total_fat = info.totals.get("fat", 0)
         total_sodium = info.totals.get("sodium", 0)
@@ -158,12 +168,19 @@ class MyFitnessPalDataUpdateCoordinator(DataUpdateCoordinator):
         _, weight = list(weights.items())[0] if len(weights) > 0 else 0, 0
 
         cardio_calories_burned = 0
+        cardio_kilojoules_burned = 0
         for exercise in info.exercises[0]:
-            cardio_calories_burned += exercise["calories burned"]
+            cardio_calories_burned += exercise.totals.get("calories burned",
+                round(exercise.totals.get("kilojoules burned", 0)  / 4.184)
+            )
+            cardio_kilojoules_burned += exercise.totals.get("kilojoules burned",
+                round(exercise.totals.get("calories burned", 0) * 4.184)
+            )
 
         result = {}
 
         result["goal_calories"] = goal_calories
+        result["goal_kilojoules"] = goal_kilojoules
         result["goal_carbohydrates"] = goal_carbohydrates
         result["goal_fat"] = goal_fat
         result["goal_sodium"] = goal_sodium
@@ -171,22 +188,29 @@ class MyFitnessPalDataUpdateCoordinator(DataUpdateCoordinator):
         result["goal_protein"] = goal_protein
 
         result["total_calories"] = total_calories
+        result["total_kilojoules"] = total_kilojoules
         result["total_carbohydrates"] = total_carbohydrates
         result["total_fat"] = total_fat
         result["total_sodium"] = total_sodium
         result["total_sugar"] = total_sugar
         result["total_protein"] = total_protein
 
+        result["cardio_kilojoules_burned"] = cardio_kilojoules_burned
         result["cardio_calories_burned"] = cardio_calories_burned
         result["water"] = water
         result["weight"] = latest_weight
         result["cal_remaining"] = goal_calories - total_calories
+        result["kj_remaining"] = goal_kilojoules - total_kilojoules
         result["cal_remaining_ex_workout"] = (
             goal_calories - total_calories - cardio_calories_burned
         )
+        result["kj_remaining_ex_workout"] = (
+            goal_kilojoules - total_kilojoules - cardio_kilojoules_burned
+        )
         result["cal_goal"] = goal_calories - cardio_calories_burned
+        result["kj_goal"] = goal_kilojoules - cardio_kilojoules_burned
         result["goal_pct"] = round(
-            (total_calories / (goal_calories + cardio_calories_burned)) * 100,
+            (total_kilojoules / (goal_kilojoules + cardio_kilojoules_burned)) * 100,
             0,
         )
 

--- a/custom_components/my_fitnesspal/entity.py
+++ b/custom_components/my_fitnesspal/entity.py
@@ -34,7 +34,7 @@ class MyFitnessPalEntity(entity.Entity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return self.coordinator.data
 


### PR DESCRIPTION
In Home Assistant 2021.4.0 extra_state_attributes was introduced as a
replacement for device_state_attributes.

This was causing the below warning to be logged:
Entity sensor.myfitnesspal [...] implements device_state_attributes.
Please report it to the custom component author.

This change replaces the function with the new one.

When attempting to setup an account with kilojoules set for energy,
a ZeroDivisionError would be generated.

This change adds support for accounts with kilojoules set for energy.
Additionally this change provides both energy units for all attributes.

Have also fixed some spelling and grammar issues in the readme.